### PR TITLE
Add Streamlit UI scaffold with custom theming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.env
+.streamlit/secrets.toml

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,12 @@
+[theme]
+primaryColor = "#0B84F3"
+backgroundColor = "#F5F7FB"
+secondaryBackgroundColor = "#FFFFFF"
+textColor = "#0C1A2A"
+font = "sans serif"
+
+[ui]
+hideTopBar = false
+
+[client]
+showErrorDetails = true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
+# AutoEdit Studio
 
+AutoEdit Studio is a Streamlit-based prototype that explores a premium
+image-editing workflow. The current milestone focuses on establishing a
+polished front-end experience with a modular architecture that will welcome
+future backend enhancements.
+
+## Project layout
+
+```
+.
+├── .streamlit/         # Centralized Streamlit configuration and theming
+├── README.md           # Project overview and setup notes
+├── pyproject.toml      # Python project metadata and dependencies
+└── src/
+    └── autoedit/
+        ├── app.py               # Streamlit entry point
+        ├── services/            # Placeholder service layer
+        │   └── image_processor.py
+        └── ui/                  # Presentation logic and global styling
+            ├── __init__.py
+            └── layout.py
+```
+
+The project follows a `src`-based layout to keep import paths explicit and to
+support packaging should the application grow into a larger service.
+
+## Getting started
+
+1. Create and activate a virtual environment (optional but recommended).
+2. Install dependencies:
+
+   ```bash
+   pip install -e .
+   ```
+
+3. Launch the Streamlit application:
+
+   ```bash
+   streamlit run src/autoedit/app.py
+   ```
+
+4. Open the URL displayed in the terminal to access the interface. Upload an
+   image, provide a prompt, and click **Render Concept** to preview the current
+   placeholder processing flow (which simply echoes back the original image).
+
+## Next steps
+
+The service layer is intentionally lightweight. It exposes a single
+`ImageProcessor` class so that future development can incorporate advanced
+model calls, prompt engineering, or multi-step image processing pipelines
+without rewriting the UI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autoedit"
+version = "0.1.0"
+description = "A Streamlit-based prototype for guided image editing."
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{name = "AutoEdit"}]
+dependencies = [
+    "streamlit>=1.31",
+    "Pillow>=10.0.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/autoedit/__init__.py
+++ b/src/autoedit/__init__.py
@@ -1,0 +1,3 @@
+"""AutoEdit package exposing the Streamlit application."""
+
+__all__ = ["app"]

--- a/src/autoedit/app.py
+++ b/src/autoedit/app.py
@@ -1,0 +1,62 @@
+"""Streamlit entry point for the AutoEdit prototype.
+
+This module wires together the UI layout with the placeholder
+image-processing service. The UI is intentionally kept light and modular so
+that future backend enhancements can reuse the same layout code without
+modification.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import streamlit as st
+
+from autoedit.services.image_processor import ImageProcessor
+from autoedit.ui import layout
+
+
+def run() -> None:
+    """Configure the Streamlit page and render the full experience."""
+    st.set_page_config(
+        page_title="AutoEdit Studio",
+        page_icon="✨",
+        layout="wide",
+        menu_items={
+            "Get Help": "https://docs.streamlit.io/",
+            "Report a bug": "https://github.com/",
+        },
+    )
+
+    layout.apply_global_styles()
+    layout.render_header()
+    with st.container():
+        user_prompt, uploaded_image = layout.render_input_panel()
+        if layout.user_requested_processing():
+            processed_image = _process_image(user_prompt, uploaded_image)
+            layout.render_output_panel(processed_image)
+
+    layout.render_footer()
+
+
+def _process_image(prompt: str, image_data: Optional[bytes]) -> Optional[bytes]:
+    """Delegate to the processing service while gracefully handling errors.
+
+    Parameters
+    ----------
+    prompt:
+        The textual instructions provided by the user.
+    image_data:
+        Raw byte representation of the user supplied image.
+    """
+    if not image_data:
+        st.info("Please upload an image to begin processing.")
+        return None
+
+    with st.spinner("Rendering your concept..."):
+        processor = ImageProcessor()
+        return processor.process(prompt=prompt, image_bytes=image_data)
+
+
+if __name__ == "__main__":
+    run()

--- a/src/autoedit/services/image_processor.py
+++ b/src/autoedit/services/image_processor.py
@@ -1,0 +1,39 @@
+"""Placeholder image processing service.
+
+The goal for now is to provide a well-documented façade that the future
+backend can extend. Returning the original image keeps the UI development
+unblocked while signalling where real processing logic will live.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class ImageProcessor:
+    """Encapsulates the image processing workflow."""
+
+    def process(self, prompt: str, image_bytes: bytes) -> Optional[bytes]:
+        """Process the provided image according to the prompt.
+
+        Parameters
+        ----------
+        prompt:
+            The textual instructions from the user.
+        image_bytes:
+            Raw bytes representing the uploaded image file.
+
+        Returns
+        -------
+        Optional[bytes]
+            The processed image bytes. `None` is returned when the input is
+            empty or processing fails.
+        """
+
+        if not image_bytes:
+            return None
+
+        # Placeholder: In the future this is where advanced image transformations
+        # will be orchestrated. Keeping the method pure and side-effect free makes
+        # it simple to test and evolve.
+        return image_bytes

--- a/src/autoedit/ui/__init__.py
+++ b/src/autoedit/ui/__init__.py
@@ -1,0 +1,19 @@
+"""UI helpers for the AutoEdit Streamlit application."""
+
+from .layout import (
+    apply_global_styles,
+    render_footer,
+    render_header,
+    render_input_panel,
+    render_output_panel,
+    user_requested_processing,
+)
+
+__all__ = [
+    "apply_global_styles",
+    "render_footer",
+    "render_header",
+    "render_input_panel",
+    "render_output_panel",
+    "user_requested_processing",
+]

--- a/src/autoedit/ui/layout.py
+++ b/src/autoedit/ui/layout.py
@@ -1,0 +1,228 @@
+"""Composable Streamlit layout elements.
+
+The functions defined here encapsulate the presentation logic for the
+application. Splitting the UI across smaller helpers keeps the Streamlit app
+readable and allows for individual sections to evolve independently.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import streamlit as st
+
+
+_PROCESS_BUTTON_KEY = "process_image_button"
+
+
+def apply_global_styles() -> None:
+    """Inject custom CSS to produce a polished, product-ready UI."""
+    st.markdown(
+        """
+        <style>
+            :root {
+                --autoedit-primary: #0B84F3;
+                --autoedit-secondary: #0C1A2A;
+                --autoedit-background: #F5F7FB;
+                --autoedit-card: #FFFFFF;
+            }
+
+            .block-container {
+                padding-top: 3rem;
+                padding-bottom: 5rem;
+                max-width: 1080px;
+            }
+
+            .hero {
+                background: linear-gradient(135deg, rgba(11, 132, 243, 0.12), rgba(11, 132, 243, 0.02));
+                border-radius: 24px;
+                padding: 3.5rem;
+                box-shadow: 0 24px 60px rgba(12, 26, 42, 0.1);
+                margin-bottom: 3rem;
+            }
+
+            .hero__badge {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                font-weight: 600;
+                font-size: 0.85rem;
+                text-transform: uppercase;
+                letter-spacing: 0.08em;
+                background: rgba(11, 132, 243, 0.12);
+                color: var(--autoedit-primary);
+                border-radius: 999px;
+                padding: 0.5rem 1.25rem;
+            }
+
+            .hero__title {
+                font-size: 2.7rem;
+                font-weight: 700;
+                color: var(--autoedit-secondary);
+                margin: 1.5rem 0 1rem;
+            }
+
+            .hero__subtitle {
+                font-size: 1.1rem;
+                line-height: 1.8;
+                color: rgba(12, 26, 42, 0.72);
+                max-width: 48rem;
+            }
+
+            .result-card {
+                background: var(--autoedit-card);
+                border-radius: 20px;
+                padding: 2rem;
+                box-shadow: 0 18px 40px rgba(12, 26, 42, 0.08);
+            }
+
+            .result-card h3 {
+                margin-top: 0;
+                font-weight: 700;
+                color: var(--autoedit-secondary);
+            }
+
+            .result-card ul {
+                padding-left: 1.2rem;
+                color: rgba(12, 26, 42, 0.72);
+                line-height: 1.7;
+            }
+
+            .footer {
+                margin-top: 4rem;
+                padding-top: 1.5rem;
+                border-top: 1px solid rgba(12, 26, 42, 0.08);
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: space-between;
+                gap: 1rem;
+                color: rgba(12, 26, 42, 0.55);
+                font-size: 0.9rem;
+            }
+
+            .footer a {
+                color: var(--autoedit-primary);
+                text-decoration: none;
+                font-weight: 600;
+            }
+
+            .stButton > button {
+                border-radius: 999px;
+                font-weight: 600;
+                letter-spacing: 0.02em;
+                padding: 0.85rem 1.8rem;
+            }
+
+            .stTextArea textarea {
+                border-radius: 20px;
+                box-shadow: inset 0 0 0 1px rgba(11, 132, 243, 0.08);
+            }
+
+            .stFileUploader > div > div {
+                border-radius: 20px;
+            }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_header() -> None:
+    """Render the hero section containing branding and onboarding text."""
+    st.markdown(
+        """
+        <div class="hero">
+            <div class="hero__badge">AutoEdit Studio</div>
+            <h1 class="hero__title">Create standout visuals with tailored guidance</h1>
+            <p class="hero__subtitle">
+                Upload an inspiration image, describe the transformation you envision,
+                and let AutoEdit craft the next iteration. This prototype currently
+                echoes your original upload, paving the way for future intelligent
+                enhancements.
+            </p>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_input_panel() -> Tuple[str, Optional[bytes]]:
+    """Display the prompt input and image upload widgets."""
+    with st.form(key="autoedit-input-form", clear_on_submit=False):
+        cols = st.columns((3, 2), gap="large")
+        with cols[0]:
+            prompt = st.text_area(
+                "Creative Brief",
+                placeholder="Describe the aesthetic, tone, or changes you'd like to explore...",
+                help="Be as descriptive as you like—mention mood, color palettes, or artistic influences.",
+                max_chars=800,
+            )
+        with cols[1]:
+            uploaded_file = st.file_uploader(
+                "Reference Visual",
+                type=["png", "jpg", "jpeg", "webp"],
+                help="High-quality PNG or JPEG works best. We'll handle the rest.",
+            )
+
+            if uploaded_file is not None:
+                st.image(uploaded_file, caption="Uploaded reference", use_column_width=True)
+                image_bytes = uploaded_file.getvalue()
+            else:
+                image_bytes = None
+
+        submit_pressed = st.form_submit_button(
+            "Render Concept",
+            use_container_width=True,
+            type="primary",
+            on_click=lambda: None,
+            help="Generate a refined visual concept using your prompt and reference.",
+        )
+        st.session_state[_PROCESS_BUTTON_KEY] = submit_pressed
+
+    return prompt, image_bytes
+
+
+def user_requested_processing() -> bool:
+    """Check whether the user triggered the processing flow in the last submit."""
+    return st.session_state.get(_PROCESS_BUTTON_KEY, False)
+
+
+def render_output_panel(image_bytes: Optional[bytes]) -> None:
+    """Show the processed image results in a polished card layout."""
+    st.divider()
+    st.markdown("## Rendered Concept")
+
+    if not image_bytes:
+        st.info("Upload an image and craft a prompt to see your results here.")
+        return
+
+    cols = st.columns((3, 2), gap="large")
+    with cols[0]:
+        st.image(image_bytes, caption="Your refined visual", use_column_width=True)
+    with cols[1]:
+        st.markdown(
+            """
+            <div class="result-card">
+                <h3>What's next?</h3>
+                <ul>
+                    <li>Iterate on your prompt to explore alternate concepts.</li>
+                    <li>Share the result with collaborators via the share menu.</li>
+                    <li>Stay tuned as AutoEdit grows smarter with every release.</li>
+                </ul>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+
+
+def render_footer() -> None:
+    """Display a minimal footer with product messaging."""
+    st.markdown(
+        """
+        <footer class="footer">
+            <span>© AutoEdit Studio — Crafted for creative professionals.</span>
+            <a href="mailto:hello@autoedit.app">Contact</a>
+        </footer>
+        """,
+        unsafe_allow_html=True,
+    )


### PR DESCRIPTION
## Summary
- add a src-based Streamlit application shell with modular UI helpers
- provide placeholder image processing service and project metadata
- configure custom theming and update project documentation

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dcdcb784208328a09e479cdf125847