### PR TITLE
Add placeholder image workflow orchestration and history UI

### DIFF
--- a/src/autoedit/services/image_processor.py
+++ b/src/autoedit/services/image_processor.py
@@ -1,20 +1,98 @@
-"""Placeholder image processing service.
+"""Image processing workflow scaffolding.
 
-The goal for now is to provide a well-documented façade that the future
-backend can extend. Returning the original image keeps the UI development
-unblocked while signalling where real processing logic will live.
+The module provides lightweight, well documented placeholders for the
+captioning, planning, and editing models that will power the AutoEdit
+experience.  Although the heavy ML models are not available in this
+prototype, the abstractions below mirror the intended behaviour so that the
+Streamlit UI can already orchestrate a realistic multi-step pipeline.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, List, Optional
+
+
+@dataclass
+class WorkflowStepResult:
+    """Summary information for an individual workflow step."""
+
+    name: str
+    status: str
+    detail: str
+
+
+@dataclass
+class ProcessResult:
+    """Aggregate output of the end-to-end image workflow."""
+
+    user_prompt: str
+    caption: str
+    refined_prompt: str
+    final_image: Optional[bytes]
+    steps: List[WorkflowStepResult]
+    created_at: datetime
+
+
+class JoyCaptionModel:
+    """Placeholder for the JoyCaption vision-language model."""
+
+    def generate_caption(self, image_bytes: bytes) -> str:
+        if not image_bytes:
+            return ""
+        # The real model would infer a rich caption. We emulate that here.
+        return (
+            "A high-resolution photograph with balanced lighting, captured in a "
+            "modern editorial style."
+        )
+
+
+class PromptOrchestrator:
+    """Simulates the lightweight LLM responsible for planning edits."""
+
+    def craft_edit_prompt(self, user_prompt: str, caption: str) -> str:
+        base_instruction = (
+            "You are QWEN-Image-Edit. Preserve key elements from the source "
+            "image while applying the requested adjustments."
+        )
+        contextual_caption = f"Context: {caption}" if caption else "Context: Unavailable."
+        user_direction = (
+            f"User brief: {user_prompt.strip()}" if user_prompt.strip() else "User brief: No additional guidance provided."
+        )
+        return " \n".join((base_instruction, contextual_caption, user_direction))
+
+
+class QwenImageEditor:
+    """Stands in for the QWEN-Image-Edit model."""
+
+    def apply_edit(self, image_bytes: bytes, refined_prompt: str) -> Optional[bytes]:
+        if not image_bytes:
+            return None
+        # Real implementation would return the edited image. For now we simply
+        # echo the input bytes so that the UI can render the uploaded image.
+        _ = refined_prompt  # The prompt is unused in the placeholder.
+        return image_bytes
+
+
+ProgressCallback = Callable[[int, str, str], None]
 
 
 class ImageProcessor:
-    """Encapsulates the image processing workflow."""
+    """Encapsulates the multi-stage image processing workflow."""
 
-    def process(self, prompt: str, image_bytes: bytes) -> Optional[bytes]:
-        """Process the provided image according to the prompt.
+    def __init__(self) -> None:
+        self._caption_model = JoyCaptionModel()
+        self._prompt_orchestrator = PromptOrchestrator()
+        self._image_editor = QwenImageEditor()
+
+    def process(
+        self,
+        prompt: str,
+        image_bytes: bytes,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> ProcessResult:
+        """Process the provided image according to the multi-step workflow.
 
         Parameters
         ----------
@@ -22,18 +100,76 @@ class ImageProcessor:
             The textual instructions from the user.
         image_bytes:
             Raw bytes representing the uploaded image file.
+        progress_callback:
+            Optional callable used to report progress updates. The callback
+            receives the step index, the new status (``"active"``,
+            ``"complete"``, or ``"error"``), and a human-readable message.
 
         Returns
         -------
-        Optional[bytes]
-            The processed image bytes. `None` is returned when the input is
-            empty or processing fails.
+        ProcessResult
+            The structured output of the workflow, including placeholder
+            captions and refined prompts.
         """
 
         if not image_bytes:
-            return None
+            return ProcessResult(
+                user_prompt=prompt,
+                caption="",
+                refined_prompt="",
+                final_image=None,
+                steps=[],
+                created_at=datetime.utcnow(),
+            )
 
-        # Placeholder: In the future this is where advanced image transformations
-        # will be orchestrated. Keeping the method pure and side-effect free makes
-        # it simple to test and evolve.
-        return image_bytes
+        def notify(step_index: int, status: str, message: str) -> None:
+            if progress_callback:
+                progress_callback(step_index, status, message)
+
+        notify(0, "active", "Extracting descriptive caption with JoyCaption...")
+        caption = self._caption_model.generate_caption(image_bytes)
+        caption_summary = caption if len(caption) <= 160 else caption[:157] + '...'
+        notify(0, "complete", f"Caption ready: {caption_summary}")
+
+        notify(1, "active", "Planning image edits with the orchestration LLM...")
+        refined_prompt = self._prompt_orchestrator.craft_edit_prompt(prompt, caption)
+        prompt_summary = refined_prompt if len(refined_prompt) <= 200 else refined_prompt[:197] + '...'
+        notify(1, "complete", f"Refined instructions prepared: {prompt_summary}")
+
+        notify(2, "active", "Applying QWEN-Image-Edit to the uploaded image...")
+        final_image = self._image_editor.apply_edit(image_bytes, refined_prompt)
+        notify(2, "complete", "Image updated with placeholder edit result.")
+
+        steps = [
+            WorkflowStepResult(
+                name="Caption Extraction",
+                status="complete",
+                detail=caption_summary,
+            ),
+            WorkflowStepResult(
+                name="Prompt Orchestration",
+                status="complete",
+                detail=prompt_summary,
+            ),
+            WorkflowStepResult(
+                name="Image Editing",
+                status="complete",
+                detail="QWEN-Image-Edit applied with the refined instructions.",
+            ),
+        ]
+
+        return ProcessResult(
+            user_prompt=prompt,
+            caption=caption,
+            refined_prompt=refined_prompt,
+            final_image=final_image,
+            steps=steps,
+            created_at=datetime.utcnow(),
+        )
+
+
+__all__ = [
+    "ImageProcessor",
+    "ProcessResult",
+    "WorkflowStepResult",
+]

--- a/src/autoedit/ui/layout.py
+++ b/src/autoedit/ui/layout.py
@@ -7,9 +7,15 @@ readable and allows for individual sections to evolve independently.
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
+
+import html
 
 import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
+
+
+from autoedit.services.image_processor import ProcessResult, WorkflowStepResult
 
 
 _PROCESS_BUTTON_KEY = "process_image_button"
@@ -86,6 +92,153 @@ def apply_global_styles() -> None:
                 padding-left: 1.2rem;
                 color: rgba(12, 26, 42, 0.72);
                 line-height: 1.7;
+            }
+
+            .result-card--metadata {
+                display: flex;
+                flex-direction: column;
+                gap: 1.25rem;
+            }
+
+            .result-card__item {
+                display: flex;
+                flex-direction: column;
+                gap: 0.4rem;
+            }
+
+            .result-card__label {
+                font-size: 0.9rem;
+                font-weight: 600;
+                text-transform: uppercase;
+                letter-spacing: 0.06em;
+                color: rgba(12, 26, 42, 0.58);
+            }
+
+            .workflow-progress {
+                margin: 2rem 0 3rem;
+                background: var(--autoedit-card);
+                border-radius: 24px;
+                padding: 1.75rem 2rem;
+                box-shadow: 0 24px 54px rgba(12, 26, 42, 0.12);
+            }
+
+            .workflow-progress__detail {
+                font-weight: 600;
+                color: var(--autoedit-secondary);
+                margin-bottom: 1.25rem;
+            }
+
+            .workflow-progress__steps {
+                display: flex;
+                align-items: center;
+                gap: 1.5rem;
+            }
+
+            .workflow-progress__step {
+                flex: 1;
+                text-align: center;
+                position: relative;
+                padding: 0 0.5rem;
+            }
+
+            .workflow-progress__step::after {
+                content: "";
+                position: absolute;
+                top: 1.45rem;
+                right: -0.75rem;
+                width: calc(100% - 1.5rem);
+                height: 3px;
+                background: rgba(12, 26, 42, 0.12);
+            }
+
+            .workflow-progress__step:last-child::after {
+                display: none;
+            }
+
+            .workflow-progress__index {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 2.2rem;
+                height: 2.2rem;
+                border-radius: 999px;
+                font-weight: 700;
+                margin: 0 auto 0.75rem;
+                background: rgba(11, 132, 243, 0.12);
+                color: var(--autoedit-primary);
+            }
+
+            .workflow-progress__label {
+                font-size: 0.95rem;
+                color: rgba(12, 26, 42, 0.78);
+                line-height: 1.4;
+            }
+
+            .workflow-progress__step--complete .workflow-progress__index {
+                background: var(--autoedit-primary);
+                color: white;
+                box-shadow: 0 12px 20px rgba(11, 132, 243, 0.25);
+            }
+
+            .workflow-progress__step--complete::after {
+                background: rgba(11, 132, 243, 0.45);
+            }
+
+            .workflow-progress__step--active .workflow-progress__index {
+                background: rgba(11, 132, 243, 0.2);
+                color: var(--autoedit-primary);
+                border: 2px solid rgba(11, 132, 243, 0.65);
+            }
+
+            .workflow-progress__step--active::after {
+                background: rgba(11, 132, 243, 0.3);
+            }
+
+            .workflow-progress__step--error .workflow-progress__index {
+                background: rgba(209, 67, 67, 0.18);
+                color: #d14343;
+            }
+
+            .workflow-progress__step--error::after {
+                background: rgba(209, 67, 67, 0.4);
+            }
+
+            .history-gallery {
+                margin-top: 2.5rem;
+            }
+
+            .history-gallery__grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+                gap: 1.5rem;
+            }
+
+            .history-card {
+                background: var(--autoedit-card);
+                border-radius: 18px;
+                padding: 1rem;
+                box-shadow: 0 12px 30px rgba(12, 26, 42, 0.08);
+                display: flex;
+                flex-direction: column;
+                gap: 0.75rem;
+            }
+
+            .history-card__image {
+                border-radius: 12px;
+                overflow: hidden;
+            }
+
+            .history-card__meta {
+                font-size: 0.85rem;
+                color: rgba(12, 26, 42, 0.7);
+                line-height: 1.5;
+            }
+
+            .history-card__timestamp {
+                font-size: 0.75rem;
+                letter-spacing: 0.05em;
+                text-transform: uppercase;
+                color: rgba(12, 26, 42, 0.45);
             }
 
             .footer {
@@ -187,32 +340,150 @@ def user_requested_processing() -> bool:
     return st.session_state.get(_PROCESS_BUTTON_KEY, False)
 
 
-def render_output_panel(image_bytes: Optional[bytes]) -> None:
-    """Show the processed image results in a polished card layout."""
+
+
+def render_workflow_progress(
+    placeholder: DeltaGenerator,
+    steps: Sequence[str],
+    statuses: Sequence[str],
+    detail_text: str,
+) -> None:
+    """Render a professional looking progress indicator for the workflow."""
+
+    status_classes: List[str] = []
+    for status in statuses:
+        if status not in {"pending", "active", "complete", "error"}:
+            status = "pending"
+        status_classes.append(status)
+
+    step_markup: List[str] = []
+    for index, (label, status) in enumerate(zip(steps, status_classes), start=1):
+        safe_label = html.escape(label)
+        step_markup.append(
+            (
+                f'<div class="workflow-progress__step workflow-progress__step--{status}">'
+                f'<div class="workflow-progress__index">{index}</div>'
+                f'<div class="workflow-progress__label">{safe_label}</div>'
+                '</div>'
+            )
+        )
+
+    placeholder.markdown(
+        (
+            "<div class=\"workflow-progress\">"
+            f"<div class=\"workflow-progress__detail\">{html.escape(detail_text)}</div>"
+            f"<div class=\"workflow-progress__steps\">{''.join(step_markup)}</div>"
+            "</div>"
+        ),
+        unsafe_allow_html=True,
+    )
+
+
+def render_output_panel(result: ProcessResult, history: Sequence[ProcessResult]) -> None:
+    """Show the processed image results alongside workflow insights."""
+
     st.divider()
     st.markdown("## Rendered Concept")
 
-    if not image_bytes:
+    if not result or not result.final_image:
         st.info("Upload an image and craft a prompt to see your results here.")
         return
 
     cols = st.columns((3, 2), gap="large")
     with cols[0]:
-        st.image(image_bytes, caption="Your refined visual", use_column_width=True)
+        st.image(result.final_image, caption="Edited visual", use_column_width=True)
+
+    user_brief = html.escape(result.user_prompt or "No brief provided.")
+    caption_text = html.escape(result.caption or "No caption generated.")
+    refined_prompt = html.escape(result.refined_prompt or "No refined prompt available.")
+
+    metadata_html = f"""
+        <div class="result-card result-card--metadata">
+            <h3>Workflow Summary</h3>
+            <div class="result-card__item">
+                <span class="result-card__label">User brief</span>
+                <p>{user_brief}</p>
+            </div>
+            <div class="result-card__item">
+                <span class="result-card__label">JoyCaption insight</span>
+                <p>{caption_text}</p>
+            </div>
+            <div class="result-card__item">
+                <span class="result-card__label">Refined edit prompt</span>
+                <p>{refined_prompt}</p>
+            </div>
+        </div>
+    """
+
     with cols[1]:
+        st.markdown(metadata_html, unsafe_allow_html=True)
+
+    step_items: List[str] = []
+    for step in result.steps:
+        detail = html.escape(step.detail or "")
+        if not detail:
+            continue
+        step_items.append(
+            f"<li><strong>{html.escape(step.name)}:</strong> {detail}</li>"
+        )
+
+    if step_items:
         st.markdown(
             """
             <div class="result-card">
-                <h3>What's next?</h3>
-                <ul>
-                    <li>Iterate on your prompt to explore alternate concepts.</li>
-                    <li>Share the result with collaborators via the share menu.</li>
-                    <li>Stay tuned as AutoEdit grows smarter with every release.</li>
-                </ul>
+                <h3>Pipeline Details</h3>
+                <ul>{items}</ul>
             </div>
-            """,
+            """.format(items="".join(step_items)),
             unsafe_allow_html=True,
         )
+
+    render_past_edits(history)
+
+
+
+def render_past_edits(history: Sequence[ProcessResult]) -> None:
+    """Display a panel of previous image edits if available."""
+
+    if not history:
+        return
+
+    entries = []
+    for previous in history[:6]:
+        if not previous.final_image:
+            continue
+        timestamp = previous.created_at.strftime("%b %d, %Y %H:%M")
+        prompt_summary = (previous.refined_prompt or "").strip() or "No refined prompt provided."
+        entries.append(
+            (
+                previous.final_image,
+                html.escape(prompt_summary),
+                html.escape(timestamp),
+            )
+        )
+
+    if not entries:
+        st.info("Past edits will appear here once available.")
+        return
+
+    st.markdown("### Past Edits")
+    st.markdown('<div class="history-gallery">', unsafe_allow_html=True)
+    cols = st.columns(min(3, len(entries)))
+
+    for idx, (image, prompt_text, timestamp) in enumerate(entries):
+        column = cols[idx % len(cols)]
+        with column:
+            st.markdown('<div class="history-card">', unsafe_allow_html=True)
+            st.image(image, use_column_width=True)
+            st.markdown(
+                """
+                <div class="history-card__meta">{prompt}</div>
+                <div class="history-card__timestamp">{timestamp}</div>
+                </div>
+                """.format(prompt=prompt_text, timestamp=timestamp),
+                unsafe_allow_html=True,
+            )
+    st.markdown('</div>', unsafe_allow_html=True)
 
 
 def render_footer() -> None:


### PR DESCRIPTION
## Summary
- orchestrate the JoyCaption → prompt planning → QWEN edit placeholder pipeline and expose progress updates in the app
- capture workflow metadata, including refined prompts and step summaries, for display alongside the latest output and past edits
- refresh global styling to support the workflow progress bar and history gallery components

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68dce291e60083288cc9cbf1c2c1a981