### PR TITLE
Improve workflow progress handling and add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,15 @@ dependencies = [
     "Pillow>=10.0.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-ra"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/src/autoedit/services/image_processor.py
+++ b/src/autoedit/services/image_processor.py
@@ -10,7 +10,7 @@ Streamlit UI can already orchestrate a realistic multi-step pipeline.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, List, Optional
 
 
@@ -119,7 +119,7 @@ class ImageProcessor:
                 refined_prompt="",
                 final_image=None,
                 steps=[],
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
         def notify(step_index: int, status: str, message: str) -> None:
@@ -164,7 +164,7 @@ class ImageProcessor:
             refined_prompt=refined_prompt,
             final_image=final_image,
             steps=steps,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
 
 

--- a/src/autoedit/ui/layout.py
+++ b/src/autoedit/ui/layout.py
@@ -350,11 +350,16 @@ def render_workflow_progress(
 ) -> None:
     """Render a professional looking progress indicator for the workflow."""
 
+    allowed_statuses = {"pending", "active", "complete", "error"}
+
     status_classes: List[str] = []
-    for status in statuses:
-        if status not in {"pending", "active", "complete", "error"}:
+    for status in list(statuses)[: len(steps)]:
+        if status not in allowed_statuses:
             status = "pending"
         status_classes.append(status)
+
+    if len(status_classes) < len(steps):
+        status_classes.extend(["pending"] * (len(steps) - len(status_classes)))
 
     step_markup: List[str] = []
     for index, (label, status) in enumerate(zip(steps, status_classes), start=1):

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from autoedit.services.image_processor import ImageProcessor, WorkflowStepResult
+
+
+def test_image_processor_success_flow():
+    processor = ImageProcessor()
+    callback_events: list[tuple[int, str, str]] = []
+
+    def callback(step_index: int, status: str, message: str) -> None:
+        callback_events.append((step_index, status, message))
+
+    prompt = "Add cinematic lighting"
+    image_bytes = b"binary-image"
+
+    result = processor.process(prompt=prompt, image_bytes=image_bytes, progress_callback=callback)
+
+    assert result.final_image == image_bytes
+    assert result.caption
+    assert result.refined_prompt
+    assert len(result.steps) == 3
+    assert all(isinstance(step, WorkflowStepResult) for step in result.steps)
+
+    assert callback_events[0][0] == 0 and callback_events[0][1] == "active"
+    assert callback_events[-1][0] == 2 and callback_events[-1][1] == "complete"
+
+
+
+def test_image_processor_handles_missing_image():
+    processor = ImageProcessor()
+
+    result = processor.process(prompt="test", image_bytes=b"")
+
+    assert result.final_image is None
+    assert result.steps == []

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from autoedit.ui import layout
+
+
+class DummyPlaceholder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bool]] = []
+
+    def markdown(self, value: str, unsafe_allow_html: bool = False) -> None:
+        self.calls.append((value, unsafe_allow_html))
+
+
+def test_render_workflow_progress_pads_missing_statuses():
+    placeholder = DummyPlaceholder()
+
+    steps = ["Caption", "Plan", "Edit"]
+    layout.render_workflow_progress(
+        placeholder=placeholder,
+        steps=steps,
+        statuses=["complete"],
+        detail_text="Running",
+    )
+
+    output, flag = placeholder.calls[-1]
+    assert flag is True
+
+    for index in range(1, len(steps) + 1):
+        assert f'class="workflow-progress__index">{index}</div>' in output
+
+
+def test_render_workflow_progress_sanitizes_statuses():
+    placeholder = DummyPlaceholder()
+
+    layout.render_workflow_progress(
+        placeholder=placeholder,
+        steps=["One"],
+        statuses=["invalid"],
+        detail_text="Testing",
+    )
+
+    output, _ = placeholder.calls[-1]
+    assert "workflow-progress__step--pending" in output


### PR DESCRIPTION
## Summary
- normalize workflow progress statuses so every configured step renders even when status data is incomplete
- switch workflow timestamps to timezone-aware datetimes to avoid deprecation warnings
- add pytest configuration plus unit tests covering the image processor and progress UI helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dce664a7e08328b1f3c3e9bcc2fca6