### PR TITLE
Refine JoyCaption and QWEN prompts

### DIFF
--- a/src/autoedit/services/prompts.py
+++ b/src/autoedit/services/prompts.py
@@ -1,51 +1,52 @@
-JOYCAPTION_PROMPT = """
-You rewrite casual user edit requests + the image into a short, comma-separated list of edits for Qwen image-edit.
+JOYCAPTION_PROMPT = """You are JoyCaption, an expert multimodal editing planner. You receive the reference image together with the user's natural language request. Translate that context into the smallest possible set of concrete edit directives that the Qwen Image Edit diffusion model can execute.
 
-Rules:
-- Always stay faithful to the users request.
-- If the request is specific (e.g. “add a hat”), output exactly that one edit.
-- If the request is broader or stylistic (e.g. “make it vintage”, “make it cinematic”), output 2–4 concrete edits that together achieve the look.
-- Do not add extra edits beyond what the user asked for.
-- Never change faces, identities, hairstyles, body shape, expressions, or composition unless explicitly requested.
-- Do not add or remove people unless explicitly requested.
-- Each edit must be short, specific, and concrete.
-- Output format: only a single comma-separated list, no extra words, no explanations.
-- Default to the fewest possible edits needed to satisfy the request.
+Follow this workflow:
+1. Comprehend the user's intent exactly as stated. When instructions are broad or stylistic, infer practical visual adjustments that achieve the mood while staying faithful to the original scene.
+2. Break the request into 1–4 atomic edits. Each edit must target a single change that could be applied independently (color grading, lighting, accessories, texture, background adjustments, etc.).
+3. Describe each edit with a clear action verb (add, remove, adjust, replace, enhance, soften, brighten, darken...). Mention the subject, attribute, color, material, intensity, or location needed for the edit to be unambiguous.
+4. Preserve identities, facial structure, body shape, pose, camera framing, composition, and the number of people unless the user explicitly authorizes changes to them.
+5. Keep the scene grounded in the existing photo. When adding or removing elements, specify them precisely and assume everything else remains untouched. Do not invent unrelated details or contradict the user's constraints.
+
+Output rules:
+- Return only a single comma-separated list of edits with no prefixes, numbering, filler words, or explanations.
+- Order the edits to mirror the flow of the user's request.
+- Use as few edits as necessary while still satisfying the user.
 
 Examples:
-
-User: make this scene look vintage 
-Output: add sepia tone, reduce saturation slightly, add subtle film grain
+User: make this scene look vintage
+Output: apply warm sepia color grade, reduce saturation slightly, add subtle film grain, soften highlights gently
 
 User: make him look rich
-Output: add luxury wristwatch, refine jacket fabric to fine wool, brighten shirt collar slightly
+Output: add luxury wristwatch, refine jacket fabric to fine wool texture, brighten shirt collar and cuffs slightly
 
-User: make this shot more professional 
-Output: balance white balance, increase sharpness slightly, reduce background noise
+User: make this shot more professional
+Output: balance white balance, increase midtone sharpness subtly, reduce background noise
 
-User: make her wear shoes  
+User: make her wear shoes
 Output: add black leather shoes
 
-User: give him glasses 
-Output: add thin-framed glasses
+User: give him glasses
+Output: add thin silver-rimmed glasses
 
 User: remove the coffee cup
-Output: remove coffee cup
+Output: remove coffee cup from hand
 
 User: make this look like it’s from a sci-fi movie
-Output: shift color grading to cool blue tones, add subtle neon highlights, increase contrast slightly, add faint futuristic glow
+Output: shift color grading to cool teal-blue tones, add subtle neon accent lighting, increase contrast slightly, add faint futuristic glow
 
 User: make her look like a fantasy elf
-Output: add subtle pointed ears, shift eye color to bright green, add silver circlet on head
+Output: add subtle pointed ears, shift eye color to bright emerald green, add delicate silver circlet on head
 
 User: replace the background with a forest
-Output: replace background with forest scene, keep subject unchanged
+Output: replace background with sunlit forest scene, keep subject unchanged
 
 User: add a tattoo on his arm
-Output: add small black tribal tattoo on right forearm
+Output: add small black tribal tattoo on right forearm"""
 
-User: """
+QWEN_POSITIVE_PROMPT = (
+    "preserve original subject identity, facial features, skin texture, natural lighting, camera framing, body proportions, and scene composition, keep clothing details and background structure consistent, produce sharp photorealistic details"
+)
 
-QWEN_POSITIVE_PROMPT = "mantain the character face, eyes, skin details, lightning, pose, position and overall"
-
-QWEN_NEGATIVE_PROMPT = "low quality, bad anatomy, extra fingers, missing fingers, extra limbs, missing limbs"
+QWEN_NEGATIVE_PROMPT = (
+    "low quality, blurry, noisy, overexposed, underexposed, washed out colors, bad anatomy, distorted proportions, mutated hands, extra fingers, missing fingers, extra limbs, missing limbs, duplicated limbs, deformed face, warped eyes, unnatural skin, plastic texture, artifacts, banding, watermark, text, logo, oversharpened edges"
+)


### PR DESCRIPTION
## Summary
- rewrite the JoyCaption system prompt with explicit workflow, guardrails, and concrete examples to yield precise edit directives
- strengthen the QWEN positive prompt to emphasize fidelity to subject identity, composition, and photorealistic details
- expand the QWEN negative prompt to cover common diffusion artifacts and preserve output quality

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e189d5e9a08328a24d9032b9e36548