### PR TITLE
Enable professional mode editing pipeline

### DIFF
--- a/src/autoedit/services/image_processor.py
+++ b/src/autoedit/services/image_processor.py
@@ -14,12 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, List, Optional
 
-import torch
-
-from services.caption_service import generate_caption
-from services.edit_service import edit_image
-
-from services.prompts import JOYCAPTION_PROMPT
+import importlib
 
 
 @dataclass
@@ -47,14 +42,18 @@ class JoyCaptionModel:
     """The JoyCaption vision-language model."""
 
     def generate_caption(self, image_bytes: bytes, prompt: str, progress_callback: Optional[ProgressCallback] = None) -> str:
-        return generate_caption(image_bytes, prompt, progress_callback)
+        caption_module = importlib.import_module("services.caption_service")
+        caption_function = getattr(caption_module, "generate_caption")
+        return caption_function(image_bytes, prompt, progress_callback)
 
 
 class QwenImageEditor:
     """Stands in for the QWEN-Image-Edit model."""
 
     def apply_edit(self, image_bytes: bytes, refined_prompt: str, progress_callback: Optional[ProgressCallback] = None) -> Optional[bytes]:
-        return edit_image(image_bytes, refined_prompt, progress_callback)
+        edit_module = importlib.import_module("services.edit_service")
+        edit_function = getattr(edit_module, "edit_image")
+        return edit_function(image_bytes, refined_prompt, progress_callback)
 
 
 ProgressCallback = Callable[[int, str, str], None]
@@ -85,6 +84,7 @@ class ImageProcessor:
         prompt: str,
         image_bytes: bytes,
         progress_callback: Optional[ProgressCallback] = None,
+        mode: str = "Casual",
     ) -> ProcessResult:
         """Process the provided image according to the multi-step workflow.
 
@@ -116,38 +116,90 @@ class ImageProcessor:
                 created_at=datetime.now(timezone.utc),
             )
 
-        refined_prompt = self._caption_model.generate_caption(image_bytes, prompt, progress_callback)
+        normalized_mode = (mode or "Casual").strip().lower()
+        is_professional = normalized_mode.startswith("pro")
 
-        caption_summary = refined_prompt if len(refined_prompt) <= 160 else refined_prompt[:157] + '...'
+        caption_text = ""
+        caption_summary = "Professional mode: used the provided prompt without JoyCaption translation."
 
-        final_image = self._image_editor.apply_edit(image_bytes, refined_prompt, progress_callback)
+        def _caption_progress(step_index: int, status: str, message: str) -> None:
+            if progress_callback:
+                progress_callback(step_index, status, message)
+
+        def _qwen_progress(step_index: int, status: str, message: str) -> None:
+            if not progress_callback:
+                return
+            if is_professional:
+                mapped_index = step_index if step_index < 2 else step_index - 2
+            else:
+                mapped_index = step_index
+            progress_callback(mapped_index, status, message)
+
+        refined_prompt = prompt
+        if not is_professional:
+            caption_callback = _caption_progress if progress_callback else None
+            caption_text = self._caption_model.generate_caption(
+                image_bytes,
+                prompt,
+                caption_callback,
+            )
+            refined_prompt = caption_text or prompt
+            caption_summary = (
+                caption_text
+                if len(caption_text) <= 160
+                else caption_text[:157] + "..."
+            )
+
+        qwen_callback = _qwen_progress if progress_callback else None
+        final_image = self._image_editor.apply_edit(
+            image_bytes,
+            refined_prompt,
+            qwen_callback,
+        )
 
         steps = [
             WorkflowStepResult(
-                name="Caption Extraction",
-                status="complete",
-                detail=caption_summary,
-            ),
-            WorkflowStepResult(
                 name="Prompt Orchestration",
                 status="complete",
-                detail="",
-            ),
+                detail="Professional mode used the provided prompt directly without JoyCaption translation."
+                if is_professional
+                else caption_summary,
+            )
+        ]
+
+        if not is_professional:
+            steps.insert(
+                0,
+                WorkflowStepResult(
+                    name="Caption Extraction",
+                    status="complete",
+                    detail=caption_summary,
+                ),
+            )
+            steps[1] = WorkflowStepResult(
+                name="Prompt Orchestration",
+                status="complete",
+                detail="JoyCaption translated the casual brief into an editing prompt.",
+            )
+
+        steps.append(
             WorkflowStepResult(
                 name="Image Editing",
                 status="complete",
                 detail="QWEN-Image-Edit applied with the refined instructions.",
-            ),
+            )
+        )
+        steps.append(
             WorkflowStepResult(
                 name="Finalization",
                 status="complete",
                 detail="Results saved and ready for display.",
-            ),
-        ]
+            )
+        )
 
         result = ProcessResult(
             user_prompt=prompt,
-            caption=refined_prompt,
+            caption=caption_text,
             refined_prompt=refined_prompt,
             final_image=final_image,
             steps=steps,

--- a/src/autoedit/services/storage_service.py
+++ b/src/autoedit/services/storage_service.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from services.image_processor import ProcessResult
+from autoedit.services.image_processor import ProcessResult
 
 
 class StorageService:

--- a/src/autoedit/ui/layout.py
+++ b/src/autoedit/ui/layout.py
@@ -784,18 +784,24 @@ def render_input_panel() -> Tuple[str, Optional[bytes]]:
         st.markdown('<div class="section-subheader">Processing mode</div>', unsafe_allow_html=True)
         mode = st.radio(
             "Choose editing mode",
-            options=["Casual", "Professional (coming soon)"],
+            options=["Casual", "Professional"],
             index=0,
-            help="Casual mode translates your prompt for you (slower, easier). Professional mode expects a detailed prompt (faster, for advanced users).",
+            help="Casual mode translates your prompt for you (slower, easier). Professional mode skips translation and expects a detailed prompt (faster, for advanced users).",
             key="autoedit_editing_mode",
             label_visibility="collapsed",
         )
+
+        tip_message = (
+            "The casual mode uses a second AI model to translate your prompt into a more detailed brief designed for best results. However, this substantially increases processing time as multiple models must be handled. Consider using professional mode for much faster results if you are familiar with image editing prompts."
+            if mode == "Casual"
+            else "Professional mode sends your prompt directly to QWEN-Image-Edit. Provide a precise, production-ready brief to take advantage of the faster turnaround."
+        )
         st.markdown(
-            """
+            f"""
             <div class="insight-card">
                 <div class="insight-card__item">
                     <strong>Tip</strong>
-                    <span class="helper-text">The casual mode uses a second AI model to translate your prompt into a more detailed brief designed for best results. However, this substantially increases processing time as multiple models must be handled. Consider using pro mode for way faster results if you are familiar with image editing prompts.</span>
+                    <span class="helper-text">{html.escape(tip_message)}</span>
                 </div>
             </div>
             """,

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 
+from types import MethodType
+
 from autoedit.services.image_processor import ImageProcessor, WorkflowStepResult
 
 
 def test_image_processor_success_flow():
-    processor = ImageProcessor()
+    processor = ImageProcessor(enable_storage=False)
     callback_events: list[tuple[int, str, str]] = []
+
+    def fake_caption(self, image_bytes: bytes, prompt: str, cb) -> str:
+        if cb:
+            cb(0, "active", "Loading JoyCaption")
+            cb(0, "complete", "JoyCaption ready")
+            cb(1, "active", "Generating caption")
+            cb(1, "complete", "Caption generated")
+        return "Refined cinematic lighting instructions"
+
+    def fake_edit(self, image_bytes: bytes, refined_prompt: str, cb):
+        if cb:
+            cb(2, "active", "Loading QWEN")
+            cb(2, "complete", "QWEN ready")
+            cb(3, "active", "Applying QWEN edits")
+            cb(3, "complete", "Edits applied")
+        return image_bytes
+
+    processor._caption_model.generate_caption = MethodType(fake_caption, processor._caption_model)
+    processor._image_editor.apply_edit = MethodType(fake_edit, processor._image_editor)
 
     def callback(step_index: int, status: str, message: str) -> None:
         callback_events.append((step_index, status, message))
@@ -13,21 +34,65 @@ def test_image_processor_success_flow():
     prompt = "Add cinematic lighting"
     image_bytes = b"binary-image"
 
-    result = processor.process(prompt=prompt, image_bytes=image_bytes, progress_callback=callback)
+    result = processor.process(prompt=prompt, image_bytes=image_bytes, progress_callback=callback, mode="Casual")
 
     assert result.final_image == image_bytes
-    assert result.caption
-    assert result.refined_prompt
-    assert len(result.steps) == 3
+    assert result.caption == "Refined cinematic lighting instructions"
+    assert result.refined_prompt == "Refined cinematic lighting instructions"
+    assert len(result.steps) == 4
     assert all(isinstance(step, WorkflowStepResult) for step in result.steps)
 
     assert callback_events[0][0] == 0 and callback_events[0][1] == "active"
-    assert callback_events[-1][0] == 2 and callback_events[-1][1] == "complete"
+    assert callback_events[-1][0] == 3 and callback_events[-1][1] == "complete"
+
+
+def test_image_processor_professional_mode_skips_caption():
+    processor = ImageProcessor(enable_storage=False)
+    caption_called = False
+    callback_events: list[tuple[int, str, str]] = []
+
+    def fake_caption(self, image_bytes: bytes, prompt: str, cb) -> str:
+        nonlocal caption_called
+        caption_called = True
+        return "Should not be used"
+
+    def fake_edit(self, image_bytes: bytes, refined_prompt: str, cb):
+        if cb:
+            cb(2, "active", "Loading QWEN")
+            cb(2, "complete", "QWEN ready")
+            cb(3, "active", "Applying QWEN edits")
+            cb(3, "complete", "Edits applied")
+        return image_bytes
+
+    processor._caption_model.generate_caption = MethodType(fake_caption, processor._caption_model)
+    processor._image_editor.apply_edit = MethodType(fake_edit, processor._image_editor)
+
+    def callback(step_index: int, status: str, message: str) -> None:
+        callback_events.append((step_index, status, message))
+
+    prompt = "Use a professional commercial-grade retouch"
+    image_bytes = b"binary-image"
+
+    result = processor.process(
+        prompt=prompt,
+        image_bytes=image_bytes,
+        progress_callback=callback,
+        mode="Professional",
+    )
+
+    assert caption_called is False
+    assert result.final_image == image_bytes
+    assert result.caption == ""
+    assert result.refined_prompt == prompt
+    assert len(result.steps) == 3
+    assert result.steps[0].detail.startswith("Professional mode")
+    assert callback_events[0][0] == 0 and callback_events[0][1] == "active"
+    assert callback_events[-1][0] == 1 and callback_events[-1][1] == "complete"
 
 
 
 def test_image_processor_handles_missing_image():
-    processor = ImageProcessor()
+    processor = ImageProcessor(enable_storage=False)
 
     result = processor.process(prompt="test", image_bytes=b"")
 


### PR DESCRIPTION
## Summary
- route the processing workflow through JoyCaption in casual mode and skip straight to QWEN edits in professional mode while keeping progress reporting accurate
- update the Streamlit UI toggle and progress indicator so professional mode only shows QWEN-related steps
- extend the image processor tests to cover both casual and professional execution paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2db7c05788328b4992baadc3b0d1c