### PR TITLE
Cache QWEN pipeline between casual edits

### DIFF
--- a/src/autoedit/services/edit_service.py
+++ b/src/autoedit/services/edit_service.py
@@ -9,8 +9,6 @@ from typing import Optional
 
 from PIL import Image
 
-from typing import Optional
-
 import torch
 from diffusers import QwenImageEditPipeline
 
@@ -19,34 +17,64 @@ from autoedit.services.prompts import QWEN_POSITIVE_PROMPT, QWEN_NEGATIVE_PROMPT
 
 MODEL_PATH = "dimitribarbot/Qwen-Image-Edit-int8wo"
 
-pipeline = None
+pipeline: Optional[QwenImageEditPipeline] = None
 
-def cleanup_pipeline():
+
+def ensure_pipeline_loaded() -> None:
     global pipeline
+    if pipeline is None:
+        pipeline = QwenImageEditPipeline.from_pretrained(
+            MODEL_PATH, torch_dtype=torch.bfloat16
+        )
+        pipeline.set_progress_bar_config(disable=None)
+
+
+def ensure_pipeline_on(device: str) -> None:
+    if pipeline is None:
+        return
+    target_device = torch.device(device)
+    current_device = getattr(pipeline, "device", None)
+    if current_device != target_device:
+        pipeline.to(target_device)
+
+
+def cleanup_pipeline() -> None:
+    """Offload the pipeline to CPU without discarding the instance."""
+
     if pipeline is not None:
-        pipeline.to("cpu")
-        pipeline = None
+        ensure_pipeline_on("cpu")
         torch.cuda.empty_cache()
 
-def edit_image(image_bytes: bytes, refined_prompt: str, is_professional: bool, progress_callback) -> Optional[bytes]:
 
-    if progress_callback:
-        progress_callback(2, "active", "Loading QWEN-Image-Edit model...")
+def edit_image(
+    image_bytes: bytes, refined_prompt: str, is_professional: bool, progress_callback
+) -> Optional[bytes]:
 
     global pipeline
-    
-    if pipeline is None:
-        pipeline = QwenImageEditPipeline.from_pretrained(MODEL_PATH, torch_dtype=torch.bfloat16)
-        pipeline.set_progress_bar_config(disable=None)
-        pipeline.to("cuda")
+
+    was_loaded = pipeline is not None
 
     if progress_callback:
-        progress_callback(2, "complete", "QWEN-Image-Edit model loaded successfully.")
+        status_message = (
+            "Loading QWEN-Image-Edit model..."
+            if not was_loaded
+            else "Preparing QWEN-Image-Edit model..."
+        )
+        progress_callback(2, "active", status_message)
+
+    ensure_pipeline_loaded()
+    ensure_pipeline_on("cuda")
+
+    if progress_callback:
+        progress_callback(2, "complete", "QWEN-Image-Edit model ready.")
 
 
     image = Image.open(io.BytesIO(image_bytes))
 
-    prompt = refined_prompt + ". mantain the character face, eyes, skin details, lightning, pose, position and overall composition)"
+    prompt = (
+        refined_prompt
+        + ". maintain the character face, eyes, skin details, lighting, pose, position and overall composition."
+    )
     inputs = {
         "image": image,
         "prompt": prompt + ", " + QWEN_POSITIVE_PROMPT,


### PR DESCRIPTION
## Summary
- cache the QWEN image edit pipeline instance so casual mode can reuse it across runs
- offload the cached pipeline to CPU during cleanup to free VRAM while avoiding reloads
- polish the prompt augmentation text used for QWEN edits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e45467b48328ac55bfd67ef35abb